### PR TITLE
Could not find Merger

### DIFF
--- a/src/services/BatchPdfExportService.php
+++ b/src/services/BatchPdfExportService.php
@@ -13,7 +13,7 @@ namespace superbig\batchpdfexport\services;
 use craft\commerce\elements\Order;
 use craft\helpers\FileHelper;
 use craft\helpers\StringHelper;
-use iio\libmergepdf\Merger;
+use iio\libmergepdf\Merger as Merger;
 use superbig\batchpdfexport\BatchPdfExport;
 use craft\commerce\Plugin as Commerce;
 


### PR DESCRIPTION
Fixing the `Class 'iio\libmergepdf\Merger' not found` error.